### PR TITLE
Update handling of class properties for mobx6/decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v6.1.1 - 2022-11-25
+
+* Flipped options for Babel plugins related to decorator and class field proposals, reverting to `loose:false` (the
+  default) as per latest MobX docs.
+    * ⚠️Required for `@enhancedBindable` decorator in Hoist React v54.
+
 ## v6.1.0 - 2022-11-21
 
 ### 🎁 New Features

--- a/configureWebpack.js
+++ b/configureWebpack.js
@@ -464,14 +464,16 @@ async function configureWebpack(env) {
 
                                         // Support our current decorator syntax, for MobX and Hoist decorators.
                                         // See notes @ https://babeljs.io/docs/en/babel-plugin-proposal-decorators#legacy
-                                        ['@babel/plugin-proposal-decorators', {legacy: true}],
+                                        // and https://mobx.js.org/enabling-decorators.html#babel-7
+                                        ['@babel/plugin-proposal-decorators', {version: 'legacy'}],
 
-                                        // Support classes level fields - must come after decorators plugin and be loose.
-                                        ['@babel/plugin-proposal-class-properties', {loose: false}],
-                                        // Must also configure private-* plugins below to config the "loose" setting
-                                        // to match plugin-proposal-class-properties.
-                                        ['@babel/plugin-proposal-private-methods', {loose: false}],
-                                        ['@babel/plugin-proposal-private-property-in-object', {loose: false}],
+                                        // Support class-level fields.
+                                        // Must come after decorators plugin as per Babel docs linked above.
+                                        ['@babel/plugin-proposal-class-properties'],
+
+                                        // Support private methods + properties.
+                                        ['@babel/plugin-proposal-private-methods'],
+                                        ['@babel/plugin-proposal-private-property-in-object'],
 
                                         // Support `let x = foo?.bar`.
                                         ['@babel/plugin-proposal-optional-chaining'],

--- a/configureWebpack.js
+++ b/configureWebpack.js
@@ -467,11 +467,11 @@ async function configureWebpack(env) {
                                         ['@babel/plugin-proposal-decorators', {legacy: true}],
 
                                         // Support classes level fields - must come after decorators plugin and be loose.
-                                        ['@babel/plugin-proposal-class-properties', {loose: true}],
+                                        ['@babel/plugin-proposal-class-properties', {loose: false}],
                                         // Must also configure private-* plugins below to config the "loose" setting
                                         // to match plugin-proposal-class-properties.
-                                        ['@babel/plugin-proposal-private-methods', {loose: true}],
-                                        ['@babel/plugin-proposal-private-property-in-object', {loose: true}],
+                                        ['@babel/plugin-proposal-private-methods', {loose: false}],
+                                        ['@babel/plugin-proposal-private-property-in-object', {loose: false}],
 
                                         // Support `let x = foo?.bar`.
                                         ['@babel/plugin-proposal-optional-chaining'],


### PR DESCRIPTION
See the following, where the need for the updated loose setting is mentioned.

This is needed for the new @bindable definition as well. Otherwise the simple setting of the class property in the constructor will overwrite the new getter/setter we are trying to provide
 
https://mobx.js.org/enabling-decorators.html. 