### PR TITLE
Fixes chunk collection. Resolves issue #29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v8.0-SNAPSHOT
+
+### 🐞 Bug Fixes
+
+* Fixed chunk collection so that similarly named apps within a project do not load each other's app chunk.
+
 ## v7.0.0 - 2023-07-19
 
 * Updated `@xh/eslint-config` to v6.0, for use with Typescript v5.1+ and Hoist React v59+.

--- a/configureWebpack.js
+++ b/configureWebpack.js
@@ -659,7 +659,7 @@ async function configureWebpack(env) {
                     template: path.resolve(hoistPath, `static/index-manifest.html`),
                     filename: `${jsAppName}/index.html`,
                     // Only include chunks that contain the js app name
-                    chunks: chunkNames.filter(it => it.includes(jsAppName)),
+                    chunks: chunkNames.filter(it => it.startsWith(jsAppName) || it.includes('~' + jsAppName)),
                     // No need to minify the HTML itself
                     minify: false,
                     // Flag read within template file to include apple icon.


### PR DESCRIPTION
In a project with many micro apps with similar names, 
such as 'pnl' and 'historical-pnl', the chunk collection test would incorrectly include the app code for both apps.