### PR TITLE
Adds xhClientApps as an available const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.2.0 - 2024-03-15
+
+* Adds `xhClientApps` as a global constant for Hoist React v61+.
+
 ## v7.1.0 - 2024-02-05
 
 * Updated to new webpack API for enabling HTTPS on local dev server. Note that the handling of the (rarely used) 

--- a/configureWebpack.js
+++ b/configureWebpack.js
@@ -620,6 +620,7 @@ async function configureWebpack(env) {
                 xhAppBuild: JSON.stringify(appBuild),
                 xhBaseUrl: JSON.stringify(baseUrl),
                 xhBuildTimestamp: buildDate.getTime(),
+                xhClientApps: JSON.stringify(appNames),
                 xhIsDevelopmentMode: !prodBuild
             }),
 


### PR DESCRIPTION
[Related PR](https://github.com/xh/hoist-react/pull/3589)

As of now, this is only to help populate the multi-select field in picking what client apps to show banners.