### PR TITLE
added new `env` option: `devServerOptions` to spread any option onto/override defaults passed to the devServer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v11.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* added new `env` option: `devServerOptions` to spread any option onto / override defaults passed to the devServer.
+
 ## v10.0.0 - 2025-01-08
 
 ### 💥 Breaking Changes

--- a/configureWebpack.js
+++ b/configureWebpack.js
@@ -108,6 +108,7 @@ try {
  *  @param {(boolean|Object)} [env.devHttps] - `true` to run webpack-dev-server locally over SSL w/o providing a cert
  *      (browser will warn). Or provide an object that will be passed to `devServer.server.options` to enable SSL and
  *      while specifying a custom cert/key. Default `false` runs locally over HTTP only. Dev-mode only.
+ *  @param {Object} [env.devServerOptions] - options to spread onto / override defaults passed here to the devServer.
  */
 async function configureWebpack(env) {
     if (!env.appCode) throw 'Missing required "appCode" config - cannot proceed';
@@ -132,6 +133,7 @@ async function configureWebpack(env) {
         devHttps = prodBuild ? null : _.isPlainObject(env.devHttps) ? env.devHttps : !!env.devHttps,
         devGrailsPort = env.devGrailsPort || 8080,
         devWebpackPort = env.devWebpackPort || 3000,
+        devServerOptions = env.devServerOptions || {},
         baseUrl = env.baseUrl || (prodBuild ? '/api/' : `//${devHost}:${devGrailsPort}/`),
         babelIncludePaths = env.babelIncludePaths || [],
         babelExcludePaths = env.babelExcludePaths || [],
@@ -750,7 +752,8 @@ async function configureWebpack(env) {
                               to: `/${appName}/index.html?_=${Date.now()}`
                           };
                       })
-                  }
+                  },
+                ...devServerOptions
               }
     };
 }


### PR DESCRIPTION
Primary motivation for this change:
Some apps have requirements to load images or files from locations on drives elsewhere in the company, and it would be very helpful to easily configure webpack dev server to act like a proxy for certain image paths, mimicking how we might configure nginx to do this in deployed environments.

Secondary reason:  
Just gives developers more freedom to easily explore any webpack dev-server options.