### PR TITLE
configureWebpack: layout-agnostic module resolution for pnpm compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,33 @@
 
 ## 14.0.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+
+* `configureWebpack()` no longer assumes a flat, physically-hoisted `node_modules` layout, making
+  the generated build config compatible with symlink/isolation-based package managers such as pnpm
+  (in addition to yarn classic and npm, which continue to work unchanged):
+    * All built-in loaders, Babel presets, and Babel plugins are now resolved to absolute paths via
+      `require.resolve()` from this package's own dependencies, rather than by bare name from the
+      consuming app's `node_modules`.
+    * The `@xh/hoist` package path (and any `babelIncludePaths`/`babelExcludePaths` entries) are
+      resolved through `fs.realpathSync()`, so Babel `include`/`exclude` rules match the real
+      module paths Webpack produces when `node_modules` entries are symlinks.
+    * The dev-utils package now locates its own bundled static assets via `__dirname`, and the
+      startup version logging for `@xh/hoist` and `react` resolves those packages from the app's
+      directory rather than relying on undeclared sibling resolution.
+
 ### 🐞 Bug Fixes
 
 * `inlineHoist` mode now aliases `react-dom` (alongside the existing `react` alias) to the app's
   own copy, ensuring both packages resolve to matching versions. React 19 throws at runtime if
   `react` and `react-dom` versions differ at all, so a patch-level drift between the app and
   hoist-react checkouts would previously break inline development.
+
+### 📚 Libraries
+
+* @babel/plugin-transform-typescript `added @ 7.28` (previously referenced as a transitive
+  dependency of @babel/preset-typescript - now declared directly, as `configureWebpack()`
+  `require.resolve()`s it)
 
 ## 13.0.1 - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,17 @@
     * All built-in loaders, Babel presets, and Babel plugins are now resolved to absolute paths via
       `require.resolve()` from this package's own dependencies, rather than by bare name from the
       consuming app's `node_modules`.
-    * The `@xh/hoist` package path (and any `babelIncludePaths`/`babelExcludePaths` entries) are
-      resolved through `fs.realpathSync()`, so Babel `include`/`exclude` rules match the real
-      module paths Webpack produces when `node_modules` entries are symlinks.
+    * The `@xh/hoist` package path (in both packaged and `inlineHoist` modes, and any
+      `babelIncludePaths`/`babelExcludePaths` entries) are resolved through `fs.realpathSync()`,
+      so Babel `include`/`exclude` rules match the real module paths Webpack produces when
+      `node_modules` entries (or checked-out project paths) are symlinks.
     * The dev-utils package now locates its own bundled static assets via `__dirname`, and the
       startup version logging for `@xh/hoist` and `react` resolves those packages from the app's
       directory rather than relying on undeclared sibling resolution.
+    * Note for apps supplying `extraModuleRules` with loaders referenced by bare name: such
+      loaders must be declared as devDependencies of the app itself. This has always been the
+      supported pattern, but isolated layouts (e.g. pnpm) now enforce it - loaders that previously
+      happened to resolve via hoisting from a transitive dependency will no longer be found.
 
 ### 🐞 Bug Fixes
 

--- a/configureWebpack.js
+++ b/configureWebpack.js
@@ -22,16 +22,18 @@ const _ = require('lodash'),
     devUtilsPkg = require('./package'),
     basePath = fs.realpathSync(process.cwd());
 
-// These are not direct deps of hoist-dev-utils, so might be undefined - e.g. when running
-// this script locally to debug via `yarn link`.
+// These are not deps of hoist-dev-utils but of the consuming app, so resolve them from the
+// app's own directory (basePath) - required under isolated/symlinked node_modules layouts
+// (e.g. pnpm), where this package cannot resolve undeclared siblings. Might still be undefined -
+// e.g. when running this script locally to debug via `yarn link`.
 let hoistReactPkg, reactPkg;
 try {
-    hoistReactPkg = require('@xh/hoist/package');
+    hoistReactPkg = require(require.resolve('@xh/hoist/package.json', {paths: [basePath]}));
 } catch (e) {
     hoistReactPkg = {version: 'NOT_FOUND'};
 }
 try {
-    reactPkg = require('react');
+    reactPkg = require(require.resolve('react/package.json', {paths: [basePath]}));
 } catch (e) {
     reactPkg = {version: 'NOT_FOUND'};
 }
@@ -133,8 +135,8 @@ async function configureWebpack(env) {
         devWebpackPort = env.devWebpackPort || 3000,
         devServerOptions = env.devServerOptions || {},
         baseUrl = env.baseUrl || '/api/',
-        babelIncludePaths = env.babelIncludePaths || [],
-        babelExcludePaths = env.babelExcludePaths || [],
+        babelIncludePaths = (env.babelIncludePaths || []).map(safeRealpath),
+        babelExcludePaths = (env.babelExcludePaths || []).map(safeRealpath),
         extraModuleRules = env.extraModuleRules || [],
         contextRoot = env.contextRoot || '/',
         copyPublicAssets = env.copyPublicAssets !== false,
@@ -185,12 +187,17 @@ async function configureWebpack(env) {
     const srcPath = path.resolve(basePath, 'src'),
         outPath = path.resolve(basePath, 'build'),
         publicAssetsPath = path.resolve(basePath, 'public'),
-        hoistDevUtilsPath = path.resolve(basePath, 'node_modules/@xh/hoist-dev-utils');
+        // This very file lives within the dev-utils package, wherever it has been installed or
+        // linked - avoids assuming the package is physically within the app's node_modules.
+        hoistDevUtilsPath = __dirname;
 
-    // Resolve Hoist as either a sibling (inline, checked-out) project or a downloaded package
+    // Resolve Hoist as either a sibling (inline, checked-out) project or a downloaded package.
+    // Resolve symlinks (a no-op for flat layouts) so the path matches the real module paths
+    // Webpack produces via its default resolve.symlinks behavior - required for the babel-loader
+    // include below to match under symlinking package managers (e.g. pnpm).
     const hoistPath = inlineHoist
         ? path.resolve(basePath, '../../hoist-react')
-        : path.resolve(basePath, 'node_modules/@xh/hoist');
+        : safeRealpath(path.resolve(basePath, 'node_modules/@xh/hoist'));
 
     // Check for and resolve standard/expected favicons.
     const manifestIcons = [];
@@ -374,9 +381,11 @@ async function configureWebpack(env) {
             extensions: ['*', '.js', '.ts', '.jsx', '.tsx', '.json']
         },
 
-        // Ensure Webpack can find loaders installed both within the top-level node_modules dir for
-        // an app that's building (standard case) or nested within dev-utils node_modules (in case
-        // of version conflict - triggered for us in Dec 2020 by postcss-loader version bump).
+        // Fallback resolution for any loaders referenced by bare name (e.g. via app-supplied
+        // extraModuleRules) - checks the app's top-level node_modules (standard case) and any
+        // nested dev-utils node_modules (in case of version conflict - triggered for us in Dec
+        // 2020 by postcss-loader version bump). Built-in loaders above are require.resolve()d to
+        // absolute paths and do not rely on this.
         resolveLoader: {
             modules: ['node_modules', devUtilsNodeModulesPath]
         },
@@ -425,13 +434,16 @@ async function configureWebpack(env) {
                         {
                             test: /\.(jsx?)$|\.(tsx?)$/,
                             use: {
-                                loader: 'babel-loader',
+                                // Loaders, presets and plugins below are deps of this package and
+                                // resolved from here via require.resolve() - apps do not get them
+                                // hoisted to their own node_modules under all layouts (e.g. pnpm).
+                                loader: require.resolve('babel-loader'),
                                 options: {
                                     presets: [
-                                        '@babel/preset-typescript',
-                                        '@babel/preset-react',
+                                        require.resolve('@babel/preset-typescript'),
+                                        require.resolve('@babel/preset-react'),
                                         [
-                                            '@babel/preset-env',
+                                            require.resolve('@babel/preset-env'),
                                             {
                                                 targets: targetBrowsers.join(', '),
 
@@ -466,14 +478,17 @@ async function configureWebpack(env) {
                                         // .js files for older JS apps. Typescript apps must use the .tsx extension for
                                         // any files containing JSX syntax.
                                         [
-                                            '@babel/plugin-transform-typescript',
+                                            require.resolve('@babel/plugin-transform-typescript'),
                                             {allowDeclareFields: true, isTSX: true}
                                         ],
 
                                         // Support our current decorator syntax, for MobX and Hoist decorators.
                                         // See notes @ https://babeljs.io/docs/en/babel-plugin-proposal-decorators#legacy
                                         // and https://mobx.js.org/enabling-decorators.html#babel-7
-                                        ['@babel/plugin-proposal-decorators', {version: 'legacy'}],
+                                        [
+                                            require.resolve('@babel/plugin-proposal-decorators'),
+                                            {version: 'legacy'}
+                                        ],
 
                                         // Avoid importing every FA icon ever made.
                                         // See https://github.com/FortAwesome/react-fontawesome/issues/70
@@ -536,11 +551,14 @@ async function configureWebpack(env) {
                                 //    called within the prod plugins section.
                                 prodBuild
                                     ? MiniCssExtractPlugin.loader
-                                    : {loader: 'style-loader', options: {esModule: false}},
+                                    : {
+                                          loader: require.resolve('style-loader'),
+                                          options: {esModule: false}
+                                      },
 
                                 // 2) Resolve @imports within CSS, similar to module support in JS.
                                 {
-                                    loader: 'css-loader',
+                                    loader: require.resolve('css-loader'),
                                     options: {
                                         importLoaders: 2, // Indicate how many prior loaders (postCssLoader/sassLoader) to also run on @imported resources.
                                         sourceMap: true,
@@ -551,12 +569,12 @@ async function configureWebpack(env) {
                                 // 1) Pre-process CSS to install vendor-specific prefixes for the configured browsers.
                                 //    Note that the "post" in the loader name refers to http://postcss.org/ - NOT the processing order within Webpack.
                                 {
-                                    loader: 'postcss-loader',
+                                    loader: require.resolve('postcss-loader'),
                                     options: {
                                         postcssOptions: {
                                             plugins: [
                                                 [
-                                                    'autoprefixer',
+                                                    require.resolve('autoprefixer'),
                                                     {
                                                         // We still want to provide an array of target browsers
                                                         // that can be passed to / managed centrally by this script.
@@ -570,7 +588,7 @@ async function configureWebpack(env) {
                                 },
 
                                 // 0) Process source SASS -> CSS
-                                {loader: 'sass-loader'}
+                                {loader: require.resolve('sass-loader')}
                             ]
                         },
 
@@ -886,6 +904,18 @@ function getFileDependenciesByEntrypoint(compilation, clientAppName) {
         });
 
     return ret;
+}
+
+// Resolve any symlinks to a real path, falling back to the given path if it does not (yet)
+// exist. No-op for flat/hoisted node_modules layouts. Required so that paths used within
+// loader include/exclude rules match the real module paths produced by Webpack's default
+// resolve.symlinks behavior under symlinking package managers (e.g. pnpm).
+function safeRealpath(p) {
+    try {
+        return fs.realpathSync(p);
+    } catch (e) {
+        return p;
+    }
 }
 
 function logSep() {

--- a/configureWebpack.js
+++ b/configureWebpack.js
@@ -71,7 +71,9 @@ try {
  *      before the built-in markdown and catch-all asset rules. Use to handle app-specific file types, or to override
  *      default asset handling for a given extension (e.g. process `.svg` via `@svgr/webpack`, or `.md` via a markdown
  *      loader). Since `oneOf` is first-match-wins, rules here take precedence over the markdown and catch-all asset
- *      rules, but not over the built-in JS/TS/CSS/image rules.
+ *      rules, but not over the built-in JS/TS/CSS/image rules. Any loaders referenced by these rules should be
+ *      declared as devDependencies of the app itself - under isolated node_modules layouts (e.g. pnpm), loaders
+ *      not declared by the app will fail to resolve.
  * @param {string} [env.contextRoot] - root path from which app will be served, used as the base path for static files.
  * @param {boolean} [env.copyPublicAssets=true] - true to copy the /client-app/public contents into the root of the
  *      build. Note that files within this directory will not be processed, named with a hash, etc. Use for static
@@ -195,9 +197,11 @@ async function configureWebpack(env) {
     // Resolve symlinks (a no-op for flat layouts) so the path matches the real module paths
     // Webpack produces via its default resolve.symlinks behavior - required for the babel-loader
     // include below to match under symlinking package managers (e.g. pnpm).
-    const hoistPath = inlineHoist
-        ? path.resolve(basePath, '../../hoist-react')
-        : safeRealpath(path.resolve(basePath, 'node_modules/@xh/hoist'));
+    const hoistPath = safeRealpath(
+        inlineHoist
+            ? path.resolve(basePath, '../../hoist-react')
+            : path.resolve(basePath, 'node_modules/@xh/hoist')
+    );
 
     // Check for and resolve standard/expected favicons.
     const manifestIcons = [];
@@ -493,7 +497,7 @@ async function configureWebpack(env) {
                                         // Avoid importing every FA icon ever made.
                                         // See https://github.com/FortAwesome/react-fontawesome/issues/70
                                         [
-                                            require('babel-plugin-transform-imports'),
+                                            require.resolve('babel-plugin-transform-imports'),
                                             {
                                                 '@fortawesome/pro-light-svg-icons': {
                                                     transform:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/plugin-proposal-decorators": "^7.28.0",
+        "@babel/plugin-transform-typescript": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,7 +725,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-typescript@^7.29.7":
+"@babel/plugin-transform-typescript@^7.28.5", "@babel/plugin-transform-typescript@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz#f0449c3df7037bbe232043476851c38f5e4a7615"
   integrity sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==


### PR DESCRIPTION
## Summary

Removes `configureWebpack()`'s assumption of a flat, physically-hoisted `node_modules` layout, making the generated build config compatible with symlink/isolation-based package managers such as pnpm. Yarn classic and npm layouts continue to work unchanged. This is a pre-req for testing pnpm at the hoist-react and app level.

- All built-in loaders, Babel presets, and Babel plugins are resolved to absolute paths via `require.resolve()` from this package's own dependencies, rather than by bare name from the consuming app's `node_modules`. `@babel/plugin-transform-typescript` is now declared as a direct dependency accordingly.
- The `@xh/hoist` package path (in both packaged and `inlineHoist` modes) and any `babelIncludePaths`/`babelExcludePaths` entries are resolved through `fs.realpathSync()`, so Babel `include`/`exclude` rules match the real module paths Webpack produces via its default `resolve.symlinks` behavior.
- The package locates its own bundled static assets via `__dirname`, and startup version logging for `@xh/hoist` and `react` resolves those packages from the app's directory rather than relying on undeclared sibling resolution.
- Documents that loaders referenced by bare name in `extraModuleRules` must be declared as app-level devDependencies - always the supported pattern, now enforced by isolated layouts.

## Compatibility notes

Not a breaking change for supported usage. One behavior change to be aware of: apps can no longer shadow a built-in loader/preset version by installing their own copy at the app level (previously possible via `resolveLoader`'s app-first ordering under flat layouts). That was never a supported technique and the new behavior is more deterministic.

## Review

Reviewed via multi-agent code review at high effort; confirmed findings (inlineHoist realpath gap, `babel-plugin-transform-imports` still passed via `require()`, undocumented pnpm loader caveat) were fixed in the follow-up commit.

## Testing

- `yarn prettier --check .` passes and the module loads cleanly.
- Next step: exercise a pnpm-installed app (Toolbox) including a prod build, dev server run, and `--env inlineHoist` with a pnpm-installed hoist-react checkout.